### PR TITLE
Ubuntu pre-requirements of CRI-O

### DIFF
--- a/vars/ubuntu-22.04.yml
+++ b/vars/ubuntu-22.04.yml
@@ -28,7 +28,7 @@ _apt_repository:
     state: "present"
 
 _apt:
-  - { state: "latest", name: "libfuse3" }
+  - { state: "latest", name: "libfuse3-3" }
   - { state: "latest", name: "conntrack" }
   - { state: "latest", name: "iproute2" }
   - { state: "latest", name: "iptables" }

--- a/vars/ubuntu-22.04.yml
+++ b/vars/ubuntu-22.04.yml
@@ -28,7 +28,7 @@ _apt_repository:
     state: "present"
 
 _apt:
-  - { state: "latest", name: "libfuse3-3" }
+  - { state: "latest", name: "fuse-overlayfs" }
   - { state: "latest", name: "conntrack" }
   - { state: "latest", name: "iproute2" }
   - { state: "latest", name: "iptables" }

--- a/vars/ubuntu-22.04.yml
+++ b/vars/ubuntu-22.04.yml
@@ -28,6 +28,7 @@ _apt_repository:
     state: "present"
 
 _apt:
+  - { state: "latest", name: "crun" }
   - { state: "latest", name: "fuse-overlayfs" }
   - { state: "latest", name: "conntrack" }
   - { state: "latest", name: "iproute2" }

--- a/vars/ubuntu-22.04.yml
+++ b/vars/ubuntu-22.04.yml
@@ -28,6 +28,7 @@ _apt_repository:
     state: "present"
 
 _apt:
+  - { state: "latest", name: "libfuse3" }
   - { state: "latest", name: "conntrack" }
   - { state: "latest", name: "iproute2" }
   - { state: "latest", name: "iptables" }


### PR DESCRIPTION
Please accept my pull request.

In a minimal installation of ubuntu 22.04, you need to include these 2 packages as pre-requirements of CRI-O.